### PR TITLE
Changes to accompany the organization name change for github.

### DIFF
--- a/crossdomain.xml
+++ b/crossdomain.xml
@@ -1,5 +1,5 @@
 <cross-domain-policy xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.adobe.com/xml/schemas/PolicyFile.xsd">
   <site-control permitted-cross-domain-policies="master-only"/>
   <allow-access-from domain="scratchx.org"/>
-  <allow-access-from domain="verniersoftwaretechnology.github.io"/>
+  <allow-access-from domain="vernierst.github.io"/>
 </cross-domain-policy>


### PR DESCRIPTION
- Wait until the MIT Team changes the URLs for ScratchX before merging.
- Change the name of this repository to vernierst.github.io once that is done